### PR TITLE
Add script to start the app as soul extension + modify readme

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
-PORT=3000
+PORT=4000
 VITE_API_URL=http://localhost:4000/api/tables
 EXTENSIONS=/absolute_path_of_your_project/_extensions

--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 PORT=3000
 VITE_API_URL=http://localhost:4000/api/tables
+EXTENSIONS=/absolute_path_of_your_project/_extensions

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # RCO-Soul
 
-## Description
+# Description
 
 The purpose of this project is to demonstrate how to run a React admin client using Soul as a REST API service. Soul is an open-source REST API wrapper that exposes an SQLite database to any client.
 
-## Running Soul and the React-admin app locally
+# Running the project locally
+
+There are two ways to run this project locally:
+
+1. Run Soul and the React Admin client independently
+2. Run the React Admin client as an extension of Soul.
+
+## 1. Running Soul and the React Admin client independently
 
 1. Install Soul on your local machine globally by running:
 
@@ -28,6 +35,7 @@ The purpose of this project is to demonstrate how to run a React admin client us
 
    - `PORT`: the port on which the Soul server runs.
    - `VITE_API_URL`: the API URL of Soul, which should be `http://localhost:<PORT>/api/tables`.
+   - `EXTENSIONS`: The **absolute path** location of the `_extensions` folder
 
 4. Start the Soul server by running:
 
@@ -41,11 +49,31 @@ The purpose of this project is to demonstrate how to run a React admin client us
    npm run dev:client
    ```
 
-## Deploying the project to Heroku
+6. To check if the app is working, use the following URL in your browser:
+   ```
+      http://localhost:<port_of_react-admin>
+   ```
+
+## 2. Running the react admin client as a soul extension
+
+1. Build the react admin client
+   ```
+     npm run build
+   ```
+2. Run the react admin app as a soul extension
+   ```
+     npm run dev:soul-client
+   ```
+3. To check if the app is working, use the following URL in your browser:
+   ```
+     http://localhost:<port>/api/client
+   ```
+
+# Deploying the project to Heroku
 
 You can deploy this project to Heroku. You can use either the Heroku CLI or create a pipeline in Heroku to automatically deploy the project when a commit is pushed to a PR.
 
-### Deploying the project using the Heroku CLI
+## Deploying the project using the Heroku CLI
 
 1. Create a new Heroku app in the Heroku dashboard.
 2. Install the Heroku CLI on your local machine.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ There are two ways to run this project locally:
    cp .env.sample .env
    ```
 
-   - `PORT`: the port on which the Soul server runs.
-   - `VITE_API_URL`: the API URL of Soul, which should be `http://localhost:<PORT>/api/tables`.
+   - `PORT`: The port on which the Soul server runs.
+   - `VITE_API_URL`: The API URL of Soul, which should be `http://localhost:<PORT>/api/tables`.
    - `EXTENSIONS`: The **absolute path** location of the `_extensions` folder
 
 4. Start the Soul server by running:

--- a/README.md
+++ b/README.md
@@ -13,21 +13,13 @@ There are two ways to run this project locally:
 
 ## 1. Running Soul and the React Admin client independently
 
-1. Install Soul on your local machine globally by running:
-
-   ```
-   npm i soul-cli -g
-   ```
-
-   NOTE: You might need admin access, so if you are on Mac or Linux, use `sudo`.
-
-2. Go to the root folder of the project and install the npm packages by running:
+1. Go to the root folder of the project and install the npm packages by running:
 
    ```
    npm install
    ```
 
-3. Copy the environment variables from the `.env.sample` file and modify the variables by running:
+2. Copy the environment variables from the `.env.sample` file and modify the variables by running:
 
    ```
    cp .env.sample .env
@@ -37,19 +29,19 @@ There are two ways to run this project locally:
    - `VITE_API_URL`: The API URL of Soul, which should be `http://localhost:<PORT>/api/tables`.
    - `EXTENSIONS`: The **absolute path** location of the `_extensions` folder
 
-4. Start the Soul server by running:
+3. Start the Soul server by running:
 
    ```
    npm run dev:soul
    ```
 
-5. Start your React-admin client in another terminal by running:
+4. Start your React-admin client in another terminal by running:
 
    ```
    npm run dev:client
    ```
 
-6. To check if the app is working, use the following URL in your browser:
+5. To check if the app is working, use the following URL in your browser:
    ```
       http://localhost:<port_of_react-admin>
    ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "npx soul-cli soul -d ./db/chinook.db -p $PORT -e /app/_extensions",
     "dev:soul": "dotenv -- cross-var soul -d ./db/chinook.db -p %PORT%",
     "dev:client": "vite",
+    "dev:soul-client": "dotenv -- cross-var soul -d ./db/chinook.db -p %PORT% -e %EXTENSIONS%",
     "build": "vite build && cp -R dist _extensions && cd _extensions && npm install",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:soul": "dotenv -- cross-var soul -d ./db/chinook.db -p %PORT%",
     "dev:client": "vite",
     "dev:soul-client": "dotenv -- cross-var soul -d ./db/chinook.db -p %PORT% -e %EXTENSIONS%",
-    "build": "vite build && cp -R dist _extensions && cd _extensions && npm install",
+    "build": "vite build && cp -R dist _extensions",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {


### PR DESCRIPTION
## Changelog 
1. Add a script to run the react admin app as souls extension 
2. Modify the instructions in the README file 
3. Modify the `.env.sample` file