### PR TITLE
Untrack db-shm and db-wal files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist
 dist-ssr
 *.local
 *.env
+*.db-shm
+*.db-wal
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
### Modifications 

1. Modified `.gitignore` to untrack `.db-shm` and `.db-wal` files